### PR TITLE
PDCL-15818: Remove incorrect binary compression mention from guardrails

### DIFF
--- a/src/pages/getting-started/guardrails.md
+++ b/src/pages/getting-started/guardrails.md
@@ -49,5 +49,3 @@ The table below shows the default limit values. If you need higher request unit 
 | Payload format | Max size for a request | Max 8 KB request fragments |
 | --- | --- | --- |
 | JSON plain-text | 64 KB | 8 |
-
-Depending on the payload itself, binary formats are generally 20-40% more compact, allowing you to push more data than you would in plain-text JSON. Contact Customer Care if you need a higher capacity for your datastreams.


### PR DESCRIPTION
## Summary

- Removes an inaccurate sentence from the HTTP Request Size Limit section of the performance guardrails page.
- The Edge Network API does not support binary compression; the sentence incorrectly implied it did and directed users to contact Customer Care for higher capacity.

## Related

Jira: [PDCL-15818]

## Test plan

- [ ] Verify the removed sentence no longer appears on the [guardrails page](https://developer.adobe.com/data-collection-apis/docs/getting-started/guardrails#http-request-size-limit)
- [ ] Confirm the HTTP Request Size Limit table and surrounding content renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)